### PR TITLE
fix: use max_rhat consistently in adaptive MCMC tuning

### DIFF
--- a/R/pipeline_main.R
+++ b/R/pipeline_main.R
@@ -91,7 +91,7 @@ res_dt <- lapply(slides, \(slide) {
 	    diagnostics <- data.table(
 	        divergent_transitions = 0.1 * stan$iter_sampling * stan$chains,
 	        ess_bulk = 20,
-	        rhat = 2
+	        max_rhat = 2
 	    ) # place holder to guarantee entry into while
 		ratchets <- -1
 		next_stan <- stan
@@ -169,8 +169,7 @@ res_dt <- lapply(slides, \(slide) {
 				"per_at_max_treedepth" = NA,
 				"ess_basic" = NA,
 				"ess_bulk" = NA,
-				"ess_tail" = NA,
-				"rhat" = NA
+				"ess_tail" = NA
 			))
 		)
 	}

--- a/R/pipeline_rescaled_weekly.R
+++ b/R/pipeline_rescaled_weekly.R
@@ -87,7 +87,7 @@ res_dt <- lapply(slides, \(slide) {
         diagnostics <- data.table(
             divergent_transitions = 0.1 * stan$iter_sampling * stan$chains,
             ess_bulk = 20,
-            rhat = 2
+            max_rhat = 2
         ) # place holder to guarantee entry into while
         ratchets <- -1
         next_stan <- stan
@@ -165,8 +165,7 @@ res_dt <- lapply(slides, \(slide) {
                 "per_at_max_treedepth" = NA_integer_,
                 "ess_basic" = NA_integer_,
                 "ess_bulk" = NA_integer_,
-                "ess_tail" = NA_integer_,
-                "rhat" = NA_integer_
+                "ess_tail" = NA_integer_
             ))
         )
     }

--- a/R/pipeline_shared_inputs.R
+++ b/R/pipeline_shared_inputs.R
@@ -230,7 +230,7 @@ keep_running <- function(
 
     passingmcmc <- c(
         dgn$divergent_transitions < dlimit,
-        dgn$rhat < rhatlim,
+        dgn$max_rhat < rhatlim,
         dgn$ess_bulk >= essmin
     ) |> sum()
 


### PR DESCRIPTION
keep_running() checked dgn$rhat but get_rstan_diagnostics() returns max_rhat. After the first model fit replaced the placeholder, dgn$rhat was NULL, so the Rhat convergence check was silently skipped — the adaptive ratchet never re-ran based on Rhat violations.

Changes:
- keep_running(): dgn$rhat -> dgn$max_rhat
- pipeline_main.R placeholder: rhat = 2 -> max_rhat = 2
- pipeline_rescaled_weekly.R placeholder: rhat = 2 -> max_rhat = 2
- Remove extraneous 'rhat' column from empty diagnostics in both pipeline scripts