### PR TITLE
Use consistent colors for forecast targets across figures

### DIFF
--- a/R/fig_panel_diagnostics.R
+++ b/R/fig_panel_diagnostics.R
@@ -90,7 +90,7 @@ ratchets_plot <- ggplot(data = daily_cases) +
         position = position_dodge2()
     ) +
     scale_x_date(NULL, date_breaks = "month", date_labels = "%b '%y") +
-    scale_color_brewer(na.translate = FALSE, palette = "Dark2") +
+    scale_fill_manual(values = target_colors, na.translate = FALSE) +
     theme(axis.text.x = element_text(angle = 90, vjust = 0.5, hjust = 1)) +
     labs(x = "Date", y = "ratchets", fill = "Forecast target")
 
@@ -139,7 +139,7 @@ diagnostics_plt <-
     ) +
     scale_y_log10() +
     scale_x_date(NULL, date_breaks = "month", date_labels = "%b '%y") +
-    scale_color_brewer(na.translate = FALSE, palette = "Dark2") +
+    scale_color_manual(values = target_colors, na.translate = FALSE) +
     labs(
         # title = "Effective sample size per second",
         x = "Date",

--- a/R/fig_panel_scores.R
+++ b/R/fig_panel_scores.R
@@ -95,7 +95,7 @@ score_plt <-
     ) +
     scale_x_date(NULL, date_breaks = "month", date_labels = "%b '%y") +
     scale_y_log10() +
-    scale_color_brewer(na.translate = FALSE, palette = "Dark2") +
+    scale_color_manual(values = target_colors, na.translate = FALSE) +
     theme(axis.text.x = element_text(angle = 90, vjust = 0.5, hjust = 1)) +
     facet_wrap(~data, ncol = 1, strip.position = "right") +
     labs(y = "CRPS (log10)",

--- a/R/pipeline_shared_inputs.R
+++ b/R/pipeline_shared_inputs.R
@@ -1,6 +1,19 @@
 library(EpiNow2) # Needed to setup EpiNow2 modules
 
 ####################################
+# Plotting
+####################################
+# Fixed colors for forecast targets (daily, weekly, rescale), shared across
+# figure scripts so the same target always maps to the same color regardless
+# of which targets/aesthetics (color vs fill) are present in a given plot.
+# Values are RColorBrewer::brewer.pal(3, "Dark2").
+target_colors <- c(
+  daily = "#1B9E77",
+  weekly = "#D95F02",
+  rescale = "#7570B3"
+)
+
+####################################
 # Functions
 ####################################
 #' Extract columns


### PR DESCRIPTION
## Summary
- Adds a shared `target_colors` palette (daily/weekly/rescale) in `R/pipeline_shared_inputs.R`
- Both `R/fig_panel_diagnostics.R` and `R/fig_panel_scores.R` now use `scale_color_manual`/`scale_fill_manual` with this palette, so the same forecast target always gets the same color across figures
- Fixes the ratchets plot in `fig_panel_diagnostics.R`, which mapped `fill = type` but was styled with `scale_color_brewer` (a no-op mismatch), so it wasn't actually sharing the intended palette

## Test plan
- [x] Reviewed the diff for correctness (palette values match previous `Dark2` 3-color output, so appearance is preserved)
- [ ] Regenerate a panel figure (`make local/figures/fig_panel_GP.png` or similar) to visually confirm consistent colors