### PR TITLE
Fix fig_crps_summary_all_provs Makefile target and clean up panel scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,13 +19,13 @@ Rscript install.R              # Initialize renv environment and restore package
 
 **Running Analyses:**
 ```bash
-make                            # Runs default target (all_scores_panel_figs)
+make                            # Runs default target (all_figs)
 make local/figures/fig_panel_GP.png  # Generate results for single province (GP)
 make test                       # Test with single province (default: GP, override with ONEPROV=WC)
 make allextracts               # Generate all data extracts (daily/weekly for all provinces)
 make all_forecasts             # Generate all forecast outputs
 make all_scores                # Generate all score outputs
-make all_panel_figs            # Generate all panel figures (scores + diagnostics)
+make all_figs                  # Generate all figures (scores + diagnostics panels + CRPS summary)
 ```
 
 **Paper Rendering:**

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ ${FIGDIR}/score_scatter_%.png: R/fig_crps.R ${OUTDIR}/score_%.rds | ${FIGDIR}
 	$(call R)
 
 ${FIGDIR}/fig_crps_summary_all_provs.png: R/fig_crps_summary_all_provs.R $(patsubst %,${OUTDIR}/score_%.rds,${PROVINCES} RSA) | ${FIGDIR}
-	$(call R)
+	Rscript $< ${OUTDIR} $@
 
 # pattern = some province
 DAILYDAT_PAT = ${DATDIR}/daily_%.rds
@@ -141,7 +141,7 @@ all_crps_figs: $(patsubst %,${FIGDIR}/score_scatter_%.png,${PROVINCES} RSA)
 all_provs_crps_summary_fig: ${FIGDIR}/fig_crps_summary_all_provs.png
 
 # Combined target for all panel figures
-all_panel_figs: all_scores_panel_figs all_diagnostics_panel_figs
+all_figs: all_scores_panel_figs all_diagnostics_panel_figs all_provs_crps_summary_fig
 
 test: ${FIGDIR}/fig_panel_scores_${ONEPROV}.png ${FIGDIR}/fig_panel_diagnostics_${ONEPROV}.png
 
@@ -157,4 +157,4 @@ paper: ${PAPEROUT}
 
 .PHONY: paper
 
-endrule: all_scores_panel_figs
+endrule: all_figs

--- a/R/fig_crps_summary_all_provs.R
+++ b/R/fig_crps_summary_all_provs.R
@@ -132,5 +132,6 @@ rel_plot <- ggplot(data = geomean_dt[slide_counts, on = .(data)]) +
 #         axis.text.x = element_text(size = 14)
 #     )
 
+if (interactive()) print(rel_plot)
 
 ggsave(tail(.args, 1), rel_plot, bg = "white", width = 12, height = 6)

--- a/R/fig_panel_diagnostics.R
+++ b/R/fig_panel_diagnostics.R
@@ -94,6 +94,8 @@ ratchets_plot <- ggplot(data = daily_cases) +
     theme(axis.text.x = element_text(angle = 90, vjust = 0.5, hjust = 1)) +
     labs(x = "Date", y = "ratchets", fill = "Forecast target")
 
+if (interactive()) print(ratchets_plot)
+
 # Add the dates by slide
 diagnostics_dt <- diagnostics_dt[
     slide_dates_dictionary,
@@ -144,8 +146,7 @@ diagnostics_plt <-
         # title = "Effective sample size per second",
         x = "Date",
         y = "ESS tail per sec (log10)",
-        color = "Forecast target",
-        linetype = "Data"
+        color = "Forecast target"
     ) +
     theme(axis.text.x = element_text(angle = 45, hjust = 1))
 
@@ -156,5 +157,7 @@ panel_fig <- (cases_plt/diagnostics_plt/ratchets_plot) &
     plot_annotation(title = paste(daily_cases$province[1])) &
     theme_minimal() &
     theme(axis.text.x = element_text(angle = 90, vjust = 0.5, hjust = 1))
+
+if (interactive()) print(panel_fig)
 
 ggsave(tail(.args, 1), panel_fig, bg = "white", width = 12, height = 6)

--- a/R/fig_panel_scores.R
+++ b/R/fig_panel_scores.R
@@ -99,7 +99,6 @@ score_plt <-
     theme(axis.text.x = element_text(angle = 90, vjust = 0.5, hjust = 1)) +
     facet_wrap(~data, ncol = 1, strip.position = "right") +
     labs(y = "CRPS (log10)",
-         linetype = "Data",
          color = "Forecast target"
     )
 
@@ -112,5 +111,6 @@ panel_fig <- (cases_plt / score_plt) &
     theme_minimal() &
     theme(axis.text.x = element_text(angle = 90, vjust = 0.5, hjust = 1))
 
+if (interactive()) print(panel_fig)
 
 ggsave(tail(.args, 1), panel_fig, bg = "white", width = 12, height = 6)


### PR DESCRIPTION
## Summary
- Fixes the `${FIGDIR}/fig_crps_summary_all_provs.png` Makefile rule: it was invoking the script with every `score_*.rds` prerequisite as positional args, but the script expects a single output directory to scan with `list.files()` — so `.args[1]` ended up as a file path, `list.files()` silently returned nothing, and the figure built from an empty dataset. Now calls `Rscript $< ${OUTDIR} $@` instead of the shared `$(call R)` macro.
- Wires `all_provs_crps_summary_fig` into the default build (`all_panel_figs` renamed to `all_figs`, now also depends on the crps summary figure; `endrule` updated accordingly).
- Adds `if (interactive()) print(<plot>)` to `fig_crps_summary_all_provs.R`, `fig_panel_diagnostics.R`, and `fig_panel_scores.R` for interactive use.
- Drops a stray `linetype = "Data"` legend label in `fig_panel_scores.R`/`fig_panel_diagnostics.R` — no `linetype` aesthetic is mapped in those plots, so it was a dead legend entry.

## Test plan
- [x] `make -n local/figures/fig_crps_summary_all_provs.png` — confirmed the printed command now matches the script's expected args
- [x] `make local/figures/fig_crps_summary_all_provs.png` — ran to completion and produced the PNG (previously failed silently on empty data)
- [ ] Regenerate a panel figure (`make local/figures/fig_panel_GP.png` or similar) to visually confirm the legend cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)