### PR TITLE
Rename keep_run_time to last_stan_elapsed_time in timing output

### DIFF
--- a/R/pipeline_main.R
+++ b/R/pipeline_main.R
@@ -149,7 +149,7 @@ res_dt <- lapply(slides, \(slide) {
           slide = slide,
           crude_run_time = crude_run_time,
           stan_elapsed_time = stan_elapsed_time,
-          keep_run_time = last_run_time,
+          last_stan_elapsed_time = last_run_time,
           ratchets = ratchets
         )
       ),
@@ -169,7 +169,7 @@ res_dt <- lapply(slides, \(slide) {
         slide = slide,
         crude_run_time = lubridate::as.duration(NA),
         stan_elapsed_time = lubridate::as.duration(NA),
-        keep_run_time = lubridate::as.duration(NA),
+        last_stan_elapsed_time = lubridate::as.duration(NA),
         ratchets = NA_integer_
       )),
       diagnostics = list(data.table(

--- a/R/pipeline_rescaled_weekly.R
+++ b/R/pipeline_rescaled_weekly.R
@@ -140,7 +140,7 @@ res_dt <- lapply(slides, \(slide) {
           slide = slide_rescaled,
           crude_run_time = crude_run_time,
           stan_elapsed_time = stan_elapsed_time,
-          keep_run_time = last_run_time,
+          last_stan_elapsed_time = last_run_time,
           ratchets = ratchets
         )
       ),
@@ -163,7 +163,7 @@ res_dt <- lapply(slides, \(slide) {
         slide = slide_rescaled,
         crude_run_time = lubridate::as.duration(NA),
         stan_elapsed_time = lubridate::as.duration(NA),
-        keep_run_time = lubridate::as.duration(NA),
+        last_stan_elapsed_time = lubridate::as.duration(NA),
         ratchets = NA_integer_
       )),
       diagnostics = list(data.table(


### PR DESCRIPTION
## Summary
- Renames the `keep_run_time` field to `last_stan_elapsed_time` in the `timing` data.table produced by both ratcheting pipelines (`R/pipeline_main.R`, `R/pipeline_rescaled_weekly.R`).
- Pure rename, no behavioral or numeric change: this value already stored the Stan elapsed time of the last (accepted) ratchet fit, distinct from the cumulative `stan_elapsed_time` next to it. The old name didn't convey that.
- Confirmed via repo-wide search that the old name isn't referenced elsewhere (`R/fig_panel_diagnostics.R`, `R/diagnostics.R`, `paper/paper.qmd` all consume the `timing` table generically, without naming this column).

## Test plan
- [x] `grep -rn "keep_run_time" R/ paper/ main/` returns no hits
- [x] `grep -rn "last_stan_elapsed_time" R/` shows the 4 expected occurrences
- [x] `Rscript -e 'parse("R/pipeline_main.R"); parse("R/pipeline_rescaled_weekly.R")'` succeeds
- [ ] `make test` (single-province smoke test) — not run in this PR due to Stan compile/MCMC runtime cost; safe given this is a column-name-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)